### PR TITLE
Fix memory leak

### DIFF
--- a/misc.hpp
+++ b/misc.hpp
@@ -257,7 +257,16 @@ inline bool is_file_exist(const std::string& fn) {
 template <typename T>
 inline std::string realname() {
     int status;
-    return abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status);
+    char* name = abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status);
+
+    std::string ret;
+    if (name) {
+        if (status == 0) {
+            ret = std::string(name);
+        }
+        free(name);
+    }
+    return ret;
 }
 
 template <typename T>


### PR DESCRIPTION
This PR fixed the memory leak from `abi::__cxa_demangle`, following https://qiita.com/yosizo@github/items/07a16ae8c4fb0fe90b23.